### PR TITLE
pending matrix set to null after been applied

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -773,6 +773,7 @@ class CanvasGraphics {
 				if (pendingMatrix != null) {
 					
 					context.transform (pendingMatrix.a, pendingMatrix.b, pendingMatrix.c, pendingMatrix.d, pendingMatrix.tx, pendingMatrix.ty);
+					pendingMatrix = null;
 				}
 
 				if (!hitTesting) context.fill ();


### PR DESCRIPTION
The pendingMatrix, if set by a previous command, was breaking the gradient matrix.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/19)

<!-- Reviewable:end -->
