### PR TITLE
Fixed addChild Logic

### DIFF
--- a/openfl/display/DisplayObjectContainer.hx
+++ b/openfl/display/DisplayObjectContainer.hx
@@ -43,12 +43,17 @@ class DisplayObjectContainer extends InteractiveObject {
 		
 		if (child != null) {
 			
-			if (child.parent != null) {
-				child.parent.removeChild (child);
+			if (child.parent == this) {
+				var childIndex = __children.indexOf(child);
+				__children.splice(childIndex,1);
+				__children.push(child);
+			} else {
+				if (child.parent != null) {
+					child.parent.removeChild (child);
+				}
+				__children.push (child);
+				initParent(child);
 			}
-			__children.push (child);
-			initParent(child);
-
 		}
 		return child;
 		


### PR DESCRIPTION
If a child is moved inside the children array ( and not switched to another parent ),
the parent should not be replaced and thus should not call removed_from_stage and added_to_stage.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/38)

<!-- Reviewable:end -->
