### PR TITLE
Fixed cacheAsBitmap value in set_filters

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -1164,8 +1164,18 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 			}
 		}
 
-		__filters = value;
-		__forceCacheAsBitmap = cacheAsBitmap = __updateFilters = value != null && value.length > 0;
+		if(value != null && value.length > 0) {
+			__forceCacheAsBitmap = true;
+			cacheAsBitmap = true;
+			__updateFilters = true;
+			__filters = value;
+		} else {
+			__forceCacheAsBitmap = false;
+			cacheAsBitmap = false;
+			__updateFilters = false;
+			__filters = null;
+		}
+
 		__setRenderDirty ();
 		
 		return value;


### PR DESCRIPTION
Fixed issue caused by set_cacheAsBitmap returned value

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/55)

<!-- Reviewable:end -->
