### PR TITLE
Fix dynamic mask

### DIFF
--- a/openfl/_internal/renderer/opengl/utils/GLMaskManager.hx
+++ b/openfl/_internal/renderer/opengl/utils/GLMaskManager.hx
@@ -103,6 +103,7 @@ class GLMaskManager extends AbstractMaskManager {
 
 			mask.visible = false;
 			@:privateAccess mask.__isMask = true;
+			@:privateAccess mask.__renderable = false;
 		}
 
 		var bitmap = @:privateAccess mask.__cachedBitmap;

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -595,6 +595,10 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 				}
 
 				__mask.__maskGraphics.clear ();
+				if( __mask.__cachedBitmap != null ){
+					__mask.__cachedBitmap.dispose();
+				}
+				__mask.__cachedBitmap = null;
 
 				__mask.__isMask = true;
 				__mask.__update (true, true, __mask.__maskGraphics);
@@ -764,6 +768,10 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 			__updateFilters = filters != null && filters.length > 0;
 			__renderDirty = true;
 			__worldRenderDirty++;
+
+			if( __isMask ){
+				__maskCached = false;
+			}
 			if (__cachedParent != null) {
 				__cachedParent.__setRenderDirty();
 			}

--- a/openfl/display/DisplayObjectContainer.hx
+++ b/openfl/display/DisplayObjectContainer.hx
@@ -834,6 +834,10 @@ class DisplayObjectContainer extends InteractiveObject {
 					}
 
 					child.__maskGraphics.clear ();
+					if( child.__cachedBitmap != null ){
+						child.__cachedBitmap.dispose();
+					}
+					child.__cachedBitmap = null;
 
 					child.__isMask = true;
 					child.__update (true, true, child.__maskGraphics);


### PR DESCRIPTION
2 problem fixed : 
- If mask was changed, the bitmap was not updated
- If mask was after the masked object in the display list, the object will be rendered as __renderable was set to true

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/71)

<!-- Reviewable:end -->
