### PR TITLE
If mouseChildren is active, don't early out of hittest when mouseEnab…

### DIFF
--- a/openfl/display/DisplayObjectContainer.hx
+++ b/openfl/display/DisplayObjectContainer.hx
@@ -474,7 +474,7 @@ class DisplayObjectContainer extends InteractiveObject {
 	
 	private override function __hitTest (x:Float, y:Float, shapeFlag:Bool, stack:Array<DisplayObject>, interactiveOnly:Bool, hitObject:DisplayObject):Bool {
 		
-		if (!hitObject.visible || __isMask || (interactiveOnly && !mouseEnabled)) return false;
+		if (!hitObject.visible || __isMask || (interactiveOnly && !mouseChildren && !mouseEnabled)) return false;
 		if (mask != null && !mask.__hitTestMask (x, y)) return false;
 		if (scrollRect != null && !scrollRect.containsPoint (globalToLocal (new Point (x, y)))) return false;
 		

--- a/openfl/display/Sprite.hx
+++ b/openfl/display/Sprite.hx
@@ -81,7 +81,7 @@ class Sprite extends DisplayObjectContainer {
 			
 		} else {
 			
-			if (!hitObject.visible || __isMask || (interactiveOnly && !mouseEnabled)) return false;
+			if (!hitObject.visible || __isMask || (interactiveOnly && !mouseChildren && !mouseEnabled)) return false;
 			if (mask != null && !mask.__hitTestMask (x, y)) return false;
 			
 			if (super.__hitTest (x, y, shapeFlag, stack, interactiveOnly, hitObject)) {

--- a/openfl/media/Sound.hx
+++ b/openfl/media/Sound.hx
@@ -200,7 +200,7 @@ class Sound extends EventDispatcher {
 		
 		if (untyped window.createjs != null) {
 			
-			SoundJS.alternateExtensions = [ "ogg", "mp3", "wav" ];
+			SoundJS.alternateExtensions = [ "m4a", "ogg" ];
 			
 		}
 		


### PR DESCRIPTION
…led is false

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/75)

<!-- Reviewable:end -->
