### PR TITLE
get_width and get_height take scale into account

### DIFF
--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -1150,7 +1150,7 @@ class TextField extends InteractiveObject {
 	private override function get_height ():Float {
 		
 		__updateLayout ();
-		return __textEngine.height;
+		return super.get_height();
 		
 	}
 	
@@ -1592,7 +1592,7 @@ class TextField extends InteractiveObject {
 	override private function get_width ():Float {
 		
 		__updateLayout ();
-		return __textEngine.width;
+		return super.get_width();
 		
 	}
 	


### PR DESCRIPTION
If you take a look at the set_width and set_height functions of this class, I believe we need to do a bit more to make this completely correct.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/82)
<!-- Reviewable:end -->
