### PR TITLE
Fixed wrong offset being computed when scaling canvas graphics

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -844,8 +844,8 @@ class CanvasGraphics {
 					graphics.__canvas.width = Math.ceil (scaled_bounds.width) + 2;
 					graphics.__canvas.height = Math.ceil (scaled_bounds.height) + 2;
 
-					context.setTransform (matrix.a, matrix.b, matrix.c, matrix.d, matrix.tx, matrix.ty);
-					context.translate (-scaled_bounds.x + 1, -scaled_bounds.y + 1);
+					context.setTransform (matrix.a, matrix.b, matrix.c, matrix.d, matrix.tx + 1, matrix.ty + 1);
+					context.translate (-scaled_bounds.x, -scaled_bounds.y);
 				}
 
 				fillStrokeCommands.clear ();

--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -864,10 +864,6 @@ import js.html.CanvasRenderingContext2D;
 		if (__bounds == null) return;
 
 		rect.__expand (__bounds.x, __bounds.y, __bounds.width, __bounds.height);
-
-		// :NOTE: The - 1 comes from the inversed offset of growing the bounds of textures by 2 pixels to allow anti aliasing on the edges. ( CanvasGraphics )
-		rect.x -= 1;
-		rect.y -= 1;
 	}
 
 

--- a/openfl/display/Shape.hx
+++ b/openfl/display/Shape.hx
@@ -1,5 +1,7 @@
 package openfl.display; #if !openfl_legacy
 
+import openfl.geom.Matrix;
+
 
 @:access(openfl.display.Graphics)
  
@@ -37,7 +39,14 @@ class Shape extends DisplayObject {
 		
 	}
 	
-	
+	public override function __updateTransforms (overrideTransform:Matrix = null):Void {
+		
+		super.__updateTransforms (overrideTransform);
+		
+		// :TRICKY: account for the extra offset added to allow anti aliasing on the edges (see CanvasGraphics.render())
+		__renderTransform.tx -= 1;
+		__renderTransform.ty -= 1;
+	}	
 }
 
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/84)
<!-- Reviewable:end -->
