### PR TITLE
Always upload complete vertex array

### DIFF
--- a/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
+++ b/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
@@ -516,12 +516,7 @@ class SpriteBatch {
 			gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
 		}
 		
-		if(writtenVertexBytes > (vertexArraySize * 0.5)) {
-			vertexArray.upload(positions);
-		} else {
-			var view = positions.subarray(0, writtenVertexBytes);
-			vertexArray.upload(view);
-		}
+		vertexArray.upload(positions);
 		
 		var nextState:State;
 		var batchSize:Int = 0;

--- a/openfl/_internal/renderer/opengl/utils/VertexArray.hx
+++ b/openfl/_internal/renderer/opengl/utils/VertexArray.hx
@@ -36,7 +36,7 @@ class VertexArray {
 		gl.bindBuffer(gl.ARRAY_BUFFER, null);
 	}
 	
-	public function upload(view:ArrayBufferView) {
+	public inline function upload(view:ArrayBufferView) {
 		gl.bufferSubData(gl.ARRAY_BUFFER, 0, view);
 	}
 	


### PR DESCRIPTION
This reduces the amount of temporary instantiated arrays.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/99)
<!-- Reviewable:end -->
