### PR TITLE
Use of a static parent list in getWorldTransform (max 32 depth)

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -405,11 +405,13 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 
 	}
 
+	private static var __parentList = new haxe.ds.Vector(32);
 	private function __getWorldTransform ():Matrix {
 
 		if (__transformDirty || __worldTransformDirty > 0) {
 
-			var list = [];
+			var list = __parentList;
+			var listIndex = 0;
 			var current = this;
 			var transformDirty = __transformDirty;
 
@@ -421,7 +423,14 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 
 				while (current.parent != null) {
 
-					list.push (current);
+					#if !js
+					if(listIndex + 1 >= list.length)
+					{
+						throw "DisplayObject.__parentList is too small.";
+					}
+					#end
+
+					list[listIndex++] = current;
 					current = current.parent;
 
 					if (current.__transformDirty) {
@@ -436,7 +445,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 
 			if (transformDirty) {
 
-				var i = list.length;
+				var i = listIndex;
 				while (--i >= 0) {
 
 					list[i].__update (true, false);


### PR DESCRIPTION
Reduces allocations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/100)
<!-- Reviewable:end -->
