### PR TITLE
Added addStaticFrameScript

### DIFF
--- a/format/swf/lite/MovieClip.hx
+++ b/format/swf/lite/MovieClip.hx
@@ -1011,6 +1011,18 @@ class MovieClip extends flash.display.MovieClip {
 			}
 
 		}
+		if (__staticFrameScripts != null) {
+
+			if (__staticFrameScripts.exists (index)) {
+				__currentLabel = __symbol.frames[index].label;
+				__staticFrameScripts.get (index) (this);
+
+				if(index  + 1 != __currentFrame){
+					return true;
+				}
+			}
+
+		}
 		#end
 
 		return false;

--- a/openfl/display/MovieClip.hx
+++ b/openfl/display/MovieClip.hx
@@ -17,6 +17,7 @@ class MovieClip extends Sprite {
 	private var __currentLabel:String;
 	private var __currentLabels:Array<FrameLabel>;
 	private var __frameScripts:Map<Int, Void->Void>;
+	private var __staticFrameScripts:Map<Int, MovieClip->Void>;
 	private var __totalFrames:Int;
 	
 	
@@ -52,6 +53,25 @@ class MovieClip extends Sprite {
 		
 	}
 	
+	public function addStaticFrameScript (index:Int, method:MovieClip->Void):Void {
+
+		if (method != null) {
+
+			if (__staticFrameScripts == null) {
+
+				__staticFrameScripts = new Map ();
+
+			}
+
+			__staticFrameScripts.set (index, method);
+
+		} else if (__staticFrameScripts != null) {
+
+			__staticFrameScripts.remove (index);
+
+		}
+
+	}
 	
 	public function gotoAndPlay (frame:Dynamic, scene:String = null):Void {
 		


### PR DESCRIPTION
Passing in a static function as framescript avoids
creating a closure for each instance of the sprite that uses it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/119)
<!-- Reviewable:end -->
