### PR TITLE
Don't calculate 9slice when it's not intersecting with bounds

### DIFF
--- a/format/swf/lite/MovieClip.hx
+++ b/format/swf/lite/MovieClip.hx
@@ -732,6 +732,12 @@ class MovieClip extends flash.display.MovieClip {
 					__scale9Rect.y -= bounds.y;
 				}
 
+				if ( !__scale9Rect.intersects(bounds) ) {
+					__9SliceBitmap = null;
+					__updating9SliceBitmap = false;
+					return;
+				}
+
 				var renderSession = @:privateAccess openfl.Lib.current.stage.__renderer.renderSession;
 
 				var bitmap = @:privateAccess BitmapData.__asRenderTexture ();


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/129)
<!-- Reviewable:end -->
