### PR TITLE
Use a separate offscreen sprite batch to allow main sprite batch to b…

### DIFF
--- a/openfl/_internal/renderer/AbstractMaskManager.hx
+++ b/openfl/_internal/renderer/AbstractMaskManager.hx
@@ -41,14 +41,6 @@ class AbstractMaskManager {
 		
 	}
 	
-	public function disableMask(){
-
-	}
-
-	public function enableMask(){
-
-	}
-
 	
 	public function popRect ():Void {
 		

--- a/openfl/_internal/renderer/RenderSession.hx
+++ b/openfl/_internal/renderer/RenderSession.hx
@@ -44,7 +44,8 @@ class RenderSession {
 	public var spriteBatch:SpriteBatch;
 	public var stencilManager:StencilManager;
 	public var defaultFramebuffer:GLFramebuffer;
-
+	public var usesMainSpriteBatch(get, never):Bool;
+	
 	private var renderTargetBaseTransformStack:GenericStack<Matrix>;
 	
 	
@@ -93,6 +94,13 @@ class RenderSession {
 	public function getRenderTargetBaseTransform ():Matrix {
 		
 		return renderTargetBaseTransformStack.first ();
+		
+	}
+	
+	public inline function get_usesMainSpriteBatch ():Bool {
+		
+		var glRenderer:openfl._internal.renderer.opengl.GLRenderer = cast renderer;
+		return spriteBatch == glRenderer.mainSpriteBatch;
 		
 	}
 

--- a/openfl/_internal/renderer/opengl/GLBitmap.hx
+++ b/openfl/_internal/renderer/opengl/GLBitmap.hx
@@ -99,14 +99,17 @@ class GLBitmap {
 		var gl:GLRenderContext = renderSession.gl;
 		if (gl == null) return null;
 
+		if (!renderSession.usesMainSpriteBatch) {
+			
+			renderSession.spriteBatch.stop ();
+		
+		}
+
 		var renderer = renderSession.renderer;
-		var spritebatch = renderSession.spriteBatch;
 		var x:Int = Std.int(viewPort.x);
 		var y:Int = Std.int(viewPort.y);
 		var width:Int = Std.int(viewPort.width);
 		var height:Int = Std.int(viewPort.height);
-
-		spritebatch.finish();
 
 		// push the default framebuffer
 		if (fbData.length <= 0) {

--- a/openfl/_internal/renderer/opengl/GLRenderer.hx
+++ b/openfl/_internal/renderer/opengl/GLRenderer.hx
@@ -58,7 +58,8 @@ class GLRenderer extends AbstractRenderer {
 	public var preserveDrawingBuffer:Bool;
 	public var projection:Point;
 	public var shaderManager:ShaderManager;
-	public var spriteBatch:SpriteBatch;
+	public var mainSpriteBatch:SpriteBatch;
+	public var offscreenSpriteBatch:SpriteBatch;
 	public var stencilManager:StencilManager;
 	public var view:Dynamic;
 	public var projectionMatrix:Matrix;
@@ -113,7 +114,8 @@ class GLRenderer extends AbstractRenderer {
 		contextLost = false;
 		
 		shaderManager = new ShaderManager (gl);
-		spriteBatch = new SpriteBatch (gl);
+		mainSpriteBatch = new SpriteBatch (gl);
+		offscreenSpriteBatch = new SpriteBatch (gl);
 		filterManager = new FilterManager (gl, this.transparent);
 		stencilManager = new StencilManager (gl);
 		blendModeManager = new BlendModeManager (gl);
@@ -124,7 +126,7 @@ class GLRenderer extends AbstractRenderer {
 		renderSession.shaderManager = this.shaderManager;
 		renderSession.filterManager = this.filterManager;
 		renderSession.blendModeManager = this.blendModeManager;
-		renderSession.spriteBatch = this.spriteBatch;
+		renderSession.spriteBatch = this.mainSpriteBatch;
 		renderSession.stencilManager = this.stencilManager;
 		renderSession.renderer = this;
 		renderSession.defaultFramebuffer = this.defaultFramebuffer;
@@ -155,12 +157,14 @@ class GLRenderer extends AbstractRenderer {
 		offset = null;
 		
 		shaderManager.destroy ();
-		spriteBatch.destroy ();
+		mainSpriteBatch.destroy ();
+		offscreenSpriteBatch.destroy ();
 		maskManager.destroy ();
 		filterManager.destroy ();
 		
 		shaderManager = null;
-		spriteBatch = null;
+		mainSpriteBatch = null;
+		offscreenSpriteBatch = null;
 		maskManager = null;
 		filterManager = null;
 		
@@ -251,7 +255,8 @@ class GLRenderer extends AbstractRenderer {
 		glContextId++;
 		
 		shaderManager.setContext (gl);
-		spriteBatch.setContext (gl);
+		mainSpriteBatch.setContext (gl);
+		offscreenSpriteBatch.setContext (gl);
 		maskManager.setContext (gl);
 		filterManager.setContext (gl);
 		
@@ -338,11 +343,14 @@ class GLRenderer extends AbstractRenderer {
 		renderSession.drawCount = 0;
 		renderSession.currentBlendMode = null;
 		
-		spriteBatch.begin (renderSession);
+		mainSpriteBatch.begin (renderSession);
+		mainSpriteBatch.preventFlush = true;
+
 		filterManager.begin (renderSession, buffer);
 		displayObject.__renderGL (renderSession);
 		
-		spriteBatch.finish();
+		mainSpriteBatch.preventFlush = false;
+		mainSpriteBatch.finish();
 		
 	}
 	
@@ -391,11 +399,9 @@ class GLRenderer extends AbstractRenderer {
 	
 	public function set_renderToTexture(renderToTexture:Bool):Bool {
 		
-		var mustReevaluateProjectionMatrix = this.renderToTexture != renderToTexture;
-
-		this.renderToTexture = renderToTexture;
-
-		if (mustReevaluateProjectionMatrix) {
+		if (this.renderToTexture != renderToTexture) {
+			this.renderToTexture = renderToTexture;
+			renderSession.spriteBatch = renderToTexture ? offscreenSpriteBatch : mainSpriteBatch;
 			setOrtho (vpX, vpY, vpWidth, vpHeight);
 		}
 

--- a/openfl/_internal/renderer/opengl/utils/GLMaskManager.hx
+++ b/openfl/_internal/renderer/opengl/utils/GLMaskManager.hx
@@ -69,7 +69,6 @@ class GLMaskManager extends AbstractMaskManager {
 
 		if (restartBatch) {
 
-			renderSession.spriteBatch.stop ();
 			renderSession.spriteBatch.start (
 				currentClip,
 				maskBitmapTable.first(),
@@ -83,7 +82,11 @@ class GLMaskManager extends AbstractMaskManager {
 
 	public override function pushMask (mask:DisplayObject) {
 
-		renderSession.spriteBatch.stop ();
+		if (!renderSession.usesMainSpriteBatch) {
+			
+			renderSession.spriteBatch.stop ();
+		
+		}
 
 		if( @:privateAccess mask.__cachedBitmap == null || @:privateAccess mask.__updateCachedBitmap ) {
 
@@ -112,14 +115,14 @@ class GLMaskManager extends AbstractMaskManager {
 
 		maskBitmapTable.add (bitmap);
 		maskMatrixTable.add (maskMatrix);
-		renderSession.spriteBatch.start (currentClip, bitmap, maskMatrix);
 
+		renderSession.spriteBatch.start (currentClip, bitmap, maskMatrix);
+		
 	}
 
 
 	public override function popMask () {
 
-		renderSession.spriteBatch.stop ();
 		maskBitmapTable.pop();
 		
 		var maskMatrix = maskMatrixTable.pop();
@@ -131,30 +134,8 @@ class GLMaskManager extends AbstractMaskManager {
 		renderSession.spriteBatch.start (currentClip, maskBitmapTable.first (),  maskMatrixTable.first ());
 	}
 
-	public override function disableMask(){
-
-		renderSession.spriteBatch.stop();
-		maskBitmapTable.add(null);
-		maskMatrixTable.add(null);
-
-	}
-
-	public override function enableMask(){
-		renderSession.spriteBatch.stop();
-		maskBitmapTable.pop();
-		var maskMatrix = maskMatrixTable.pop();
-		
-		if (maskMatrix != null) {
-			throw "maskMatrix should always be null here";
-			Matrix.pool.put (maskMatrix);
-		}
-		renderSession.spriteBatch.start( currentClip, maskBitmapTable.first(), maskMatrixTable.first());
-	}
-
 
 	override public function popRect():Void {
-
-		renderSession.spriteBatch.stop ();
 
 		clips.pop ();
 		currentClip = clips[clips.length - 1];

--- a/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
+++ b/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
@@ -49,6 +49,7 @@ class SpriteBatch {
 	
 	var dirty:Bool = true;
 	public var drawing:Bool = false;
+	public var preventFlush:Bool = false;
 	
 	var clipRect:Rectangle;
 	var maskBitmap:BitmapData;
@@ -150,10 +151,6 @@ class SpriteBatch {
 	}
 
 	public function start(clipRect:Rectangle, mask: BitmapData = null, maskMatrix:Matrix = null) {
-		if (drawing) {
-			stop();
-		}
-
 		drawing = true;
 		dirty = true;
 
@@ -505,6 +502,9 @@ class SpriteBatch {
 	}
 	
 	function flush() {
+		
+		if (preventFlush) throw "SpriteBatch flush forbidden";
+		
 		if (batchedSprites == 0) return;
 		
 		if (clipRect != null) {
@@ -654,7 +654,8 @@ class SpriteBatch {
 			state.maskTexture = maskBitmap.getTexture(gl);
 			var uvData = @:privateAccess maskBitmap.__uvData;
 			state.maskTextureUVScale.setTo( uvData.x1, uvData.y2 );
-			state.maskMatrix = maskMatrix;
+			state.maskMatrix = Matrix.pool.get ();
+			state.maskMatrix.copyFrom (maskMatrix);
 		} else {
 			state.maskTexture = null;
 		}
@@ -772,6 +773,10 @@ private class State {
 		texture = null;
 		colorTransform = null;
 		maskTexture = null;
-		maskMatrix = null;
+		
+		if (maskMatrix != null) {
+			Matrix.pool.put (maskMatrix);
+			maskMatrix = null;
+		}
 	}
 }

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -662,8 +662,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 			return;
 		}
 
-		renderSession.maskManager.disableMask ();
-
 		if (__cachedBitmap == null) {
 			__cachedBitmap = @:privateAccess BitmapData.__asRenderTexture ();
 		}
@@ -695,8 +693,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 
 		@:privateAccess __cachedBitmap.__scaleX = renderScaleX;
 		@:privateAccess __cachedBitmap.__scaleY = renderScaleY;
-
-		renderSession.maskManager.enableMask ();
 
 	}
 	


### PR DESCRIPTION
…e flushed only once per frame and avoid framebuffer pingpong

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/136)
<!-- Reviewable:end -->
