### PR TITLE
Better way of handling calls to bindvertexarray.

### DIFF
--- a/openfl/_internal/renderer/opengl/shaders2/Shader.hx
+++ b/openfl/_internal/renderer/opengl/shaders2/Shader.hx
@@ -21,7 +21,6 @@ import openfl.utils.UnsafeStringMap;
 class Shader {
 	
 	private static var UID:Int = 0;
-	private static var currentVertexArray:VertexArray = null;
  	
 	public var gl:GLRenderContext;
 	
@@ -187,9 +186,6 @@ class Shader {
 	}
 	
 	public function bindVertexArray(va:VertexArray) {
-		if (va == currentVertexArray) {
-			return;
-		}
 
 		var offset = 0;
 		var stride = va.stride;
@@ -203,7 +199,6 @@ class Shader {
 			}
 		}
 		
-		currentVertexArray = va;
 	}
 	
 	public function unbindVertexArray(va:VertexArray) {
@@ -211,7 +206,6 @@ class Shader {
 			disableVertexAttribute(attribute, false);
 		}
 
-		currentVertexArray = null;
 	}
 	
 	

--- a/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
+++ b/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
@@ -609,10 +609,13 @@ class SpriteBatch {
 		var shader:Shader = state.shader == null ?
 			( state.maskTexture != null ? renderSession.shaderManager.defaultMaskedShader : renderSession.shaderManager.defaultShader )
 			: state.shader;
-		renderSession.shaderManager.setShader(shader);
 
-		// TODO cache this somehow?, don't do each state change?
-		shader.bindVertexArray(vertexArray);
+		var updatedShader = false;
+		if ( renderSession.shaderManager.currentShader != shader ) {
+			renderSession.shaderManager.setShader(shader);
+			shader.bindVertexArray(vertexArray);
+			updatedShader = true;
+		}
 
 		renderSession.blendModeManager.setBlendMode(shader.blendMode != null ? shader.blendMode : state.blendMode);
 
@@ -644,9 +647,10 @@ class SpriteBatch {
 			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
 		}
 
-		gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, shader.wrapS);
-		gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, shader.wrapT);
-
+		if ( updatedShader ) {
+			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, shader.wrapS);
+			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, shader.wrapT);
+		}
 
 		if (state.maskTexture != null){
 			gl.activeTexture(gl.TEXTURE0 + 1);

--- a/openfl/display/OpenGLView.hx
+++ b/openfl/display/OpenGLView.hx
@@ -200,7 +200,6 @@ class OpenGLView extends DirectRenderer {
 			renderSession.shaderManager.setShader(null);
 			renderSession.blendModeManager.setBlendMode(null);
 			renderSession.renderer.setViewport(0,0,stage.stageWidth, stage.stageHeight, true);
-			@:privateAccess openfl._internal.renderer.opengl.shaders2.Shader.currentVertexArray = null;
 		}
 		
 	}


### PR DESCRIPTION
The previous implementation was incomplete.
bindVertexArray should be called each time the shader changes. not when the vertexarray changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/143)
<!-- Reviewable:end -->
