### PR TITLE
Reversed loop in addChildAtSwfDepth

### DIFF
--- a/format/swf/lite/MovieClip.hx
+++ b/format/swf/lite/MovieClip.hx
@@ -1083,16 +1083,17 @@ class MovieClip extends flash.display.MovieClip {
 
 		__SWFDepthData.set(displayObject, targetDepth);
 
-		for( i in 0 ... numChildren ){
+		var i = numChildren - 1;
+		while( i >= 0 ){
 			var child = getChildAt(i);
-			if( __SWFDepthData.get(child) > targetDepth){
-				addChildAt (displayObject, i);
-
+			if( __SWFDepthData.get(child) <= targetDepth){
+				addChildAt (displayObject, i+1);
 				return;
 			}
+			--i;
 		}
 
-		addChild (displayObject);
+		addChildAt(displayObject, 0);
 	}
 
 	public override function removeChild (child:DisplayObject):DisplayObject {


### PR DESCRIPTION
99% of the time it is used to add as last child

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/227)
<!-- Reviewable:end -->
