### PR TITLE
Added Tools.viewBitmapData(bitmapData)

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -1364,7 +1364,19 @@ class BitmapData implements IBitmapDrawable {
 
 		var theTitle = "Preview: " + width + "x" + height;
 
-		untyped $(canvas).dialog({ title: theTitle }).parent().draggable({cancel:'',handle:''});
+		untyped $(canvas)
+			.dialog({
+				title: theTitle,
+				width: width,
+				height: height,
+				resizable: false
+				})
+			.parent()
+			.draggable({
+				cancel:'',
+				handle:'',
+				containment: false
+				});
 	}
 	#end
 }

--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -1333,6 +1333,40 @@ class BitmapData implements IBitmapDrawable {
 		}
 
 	}
+
+	#if (dev && js)
+	public static function __init__ () {
+		untyped $global.Tools = $global.Tools || {};
+		untyped $global.Tools.viewBitmapData = viewBitmapData;
+	}
+
+	private static function viewBitmapData(bitmapData:BitmapData) {
+		var gl = bitmapData.__pingPongTexture.gl;
+		var texture = bitmapData.__pingPongTexture.texture;
+		var width = bitmapData.physicalWidth;
+		var height = bitmapData.physicalHeight;
+
+		var framebuffer = gl.createFramebuffer();
+		gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+		gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+		var data = new js.html.Uint8Array(width * height * 4);
+		gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, data);
+		gl.deleteFramebuffer(framebuffer);
+
+		var canvas = untyped $global.document.createElement('canvas');
+		canvas.width = width;
+		canvas.height = height;
+		var context = canvas.getContext('2d');
+
+		var imageData = context.createImageData(width, height);
+		imageData.data.set(data);
+		context.putImageData(imageData, 0, 0);
+
+		var theTitle = "Preview: " + width + "x" + height;
+
+		untyped $(canvas).dialog({ title: theTitle }).parent().draggable({cancel:'',handle:''});
+	}
+	#end
 }
 
 

--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -1341,8 +1341,8 @@ class BitmapData implements IBitmapDrawable {
 	}
 
 	private static function viewBitmapData(bitmapData:BitmapData) {
-		var gl = bitmapData.__pingPongTexture.gl;
-		var texture = bitmapData.__pingPongTexture.texture;
+		var gl = @:privateAccess Lib.current.stage.__renderer.renderSession.gl;
+		var texture = bitmapData.getTexture(gl);
 		var width = bitmapData.physicalWidth;
 		var height = bitmapData.physicalHeight;
 


### PR DESCRIPTION
This depends on Jquery-ui, see https://github.com/FishingCactus/lime/pull/25

Just break in the generated js code and call 'Tools.viewBitmapData(yourBitmapData);'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/248)
<!-- Reviewable:end -->
