### PR TITLE
Perform full update when calling BitmapData.draw() to update render a…

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -445,8 +445,7 @@ class BitmapData implements IBitmapDrawable {
 			cached_visible = src_display_object.visible && src_display_object.__renderable;
 			if ( !cached_visible ) {
 				src_display_object.visible = true;
-				// :NOTE: Need to call __update here to refresh the __renderable flag
-				src_display_object.__update(true, true);
+				src_display_object.__update(false, true);
 			}
 		}
 		__drawGL ( renderSession, source, matrix, clipRect, smoothing, !__usingPingPongTexture, false, true);


### PR DESCRIPTION
…lpha/color transform

This fixes rendering issues with objects (e.g. invalid renderAlpha) that have never been added to the hierarchy and have thus never been updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/249)
<!-- Reviewable:end -->
