### PR TITLE
Transform dirty shouldn't have to recompute filters.

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -857,7 +857,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 		if (!__transformDirty) {
 
 			__transformDirty = true;
-			__setRenderDirty();
+			__setRenderDirtyNoCachedBitmap();
 			__worldTransformDirty++;
 
 		}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/254)
<!-- Reviewable:end -->
