### PR TITLE
Set Correct symbolId for "removed" symbols.

### DIFF
--- a/format/swf/lite/MovieClip.hx
+++ b/format/swf/lite/MovieClip.hx
@@ -401,7 +401,7 @@ class MovieClip extends flash.display.MovieClip {
 				}
 			}
 
-			Reflect.setField( displayObject, "symbolId", symbol.id );
+			Reflect.setField( displayObject, "symbolId", object.symbol );
 
 			if (object.name != null) {
 


### PR DESCRIPTION
if you exclude a symbol, a dummy frameObject will be created. We can use this to replace the
original shape with a custom spritesheet for example.

The frameObject does not have the symbol.id setup correctly.
object.symbol is correct and matches symbol.id

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/261)
<!-- Reviewable:end -->
