### PR TITLE
Fixed forbidCachedBitmapUpdate behavior

### DIFF
--- a/format/swf/lite/MovieClip.hx
+++ b/format/swf/lite/MovieClip.hx
@@ -423,7 +423,7 @@ class MovieClip extends flash.display.MovieClip {
 	private function __createShape (symbol:ShapeSymbol):Shape {
 
 		var shape = new Shape ();
-		__forbidCachedBitmapUpdate = symbol.forbidCachedBitmapUpdate;
+		shape.__forbidCachedBitmapUpdate = symbol.forbidCachedBitmapUpdate;
 
 		if ( @:privateAccess symbol.graphics.__owner != null ) {
 			@:privateAccess shape.__graphics = new Graphics(false);

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -719,7 +719,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 
 	public inline function __cacheGL (renderSession:RenderSession):Void {
 
-		if ( ( __updateCachedBitmap && ( !__forbidCachedBitmapUpdate || __cachedBitmap == null ) ) || __updateFilters) {
+		if ( ( __updateCachedBitmap || __updateFilters ) && ( !__forbidCachedBitmapUpdate || __cachedBitmap == null ) ) {
 
  			__updateCachedBitmapFn (renderSession);
 


### PR DESCRIPTION
The behavior was wrong (setting a flag in a parent object)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/263)
<!-- Reviewable:end -->
