### PR TITLE
Feature useUniqueSharedBitmapCache

### DIFF
--- a/format/swf/lite/MovieClip.hx
+++ b/format/swf/lite/MovieClip.hx
@@ -423,7 +423,7 @@ class MovieClip extends flash.display.MovieClip {
 	private function __createShape (symbol:ShapeSymbol):Shape {
 
 		var shape = new Shape ();
-		__forbidCachedBitmapUpdate = symbol.forbidCachedBitmapUpdate;
+		shape.__forbidCachedBitmapUpdate = symbol.forbidCachedBitmapUpdate;
 
 		if ( @:privateAccess symbol.graphics.__owner != null ) {
 			@:privateAccess shape.__graphics = new Graphics(false);

--- a/format/swf/lite/symbols/SWFSymbol.hx
+++ b/format/swf/lite/symbols/SWFSymbol.hx
@@ -2,22 +2,21 @@ package format.swf.lite.symbols;
 
 import openfl.ObjectPool;
 import openfl.display.DisplayObject;
-
+import openfl.display.BitmapData;
 
 @:keepSub class SWFSymbol {
 	
 	
 	public var className:String;
 	public var id:Int;
-
 	public var poolable(default, set):Bool = false;
-
 	public var pool:ObjectPool<DisplayObject>;
+	public var useUniqueSharedBitmapCache = false;
+	public var uniqueSharedCachedBitmap:BitmapData = null;
 
 	public function new () {
 
 	}
-	
 
 	public function set_poolable(value:Bool):Bool {
 

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -675,6 +675,14 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 			return;
 		}
 
+		var symbol = getSymbol();
+
+		if(symbol != null && symbol.useUniqueSharedBitmapCache && symbol.uniqueSharedCachedBitmap != null) {
+			__cachedBitmap = symbol.uniqueSharedCachedBitmap;
+			__forbidCachedBitmapUpdate = true;
+			return;
+		}
+
 		if (__cachedBitmap == null) {
 			__cachedBitmap = @:privateAccess BitmapData.__asRenderTexture ();
 		}
@@ -715,6 +723,9 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 		@:privateAccess __cachedBitmap.__scaleX = renderScaleX;
 		@:privateAccess __cachedBitmap.__scaleY = renderScaleY;
 
+		if(symbol != null && symbol.useUniqueSharedBitmapCache) {
+			symbol.uniqueSharedCachedBitmap = __cachedBitmap;
+		}
 	}
 
 	public inline function __cacheGL (renderSession:RenderSession):Void {
@@ -798,7 +809,10 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 		}
 
 		if (__cachedBitmap != null) {
-			__cachedBitmap.dispose();
+			var symbol = getSymbol();
+			if(symbol == null || !symbol.useUniqueSharedBitmapCache) {
+				__cachedBitmap.dispose();
+			}
 			__cachedBitmap = null;
 			dirty = true;
 		}

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -719,7 +719,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 
 	public inline function __cacheGL (renderSession:RenderSession):Void {
 
-		if ( ( __updateCachedBitmap && ( !__forbidCachedBitmapUpdate || __cachedBitmap == null ) ) || __updateFilters) {
+		if ( ( __updateCachedBitmap || __updateFilters ) && ( !__forbidCachedBitmapUpdate || __cachedBitmap == null ) ) {
 
  			__updateCachedBitmapFn (renderSession);
 


### PR DESCRIPTION
This can be applied to any symbol (shape, sprite, movieclip, etc.)

The rule is simple : the first time it is rendered it will be cached and shared among all object having the same symbol.

If others have different filters they will not be applied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/264)
<!-- Reviewable:end -->
