### PR TITLE
WIP: reduce canvas => webgl texture conversions

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasTextField.hx
+++ b/openfl/_internal/renderer/canvas/CanvasTextField.hx
@@ -342,7 +342,6 @@ class CanvasTextField {
 
 				}
 
-				graphics.__bitmap = BitmapData.fromCanvas (textField.__graphics.__canvas, scaleX, scaleY);
 				textField.__dirty = false;
 				graphics.__dirty = false;
 

--- a/openfl/_internal/renderer/opengl/GLRenderer.hx
+++ b/openfl/_internal/renderer/opengl/GLRenderer.hx
@@ -314,6 +314,7 @@ class GLRenderer extends AbstractRenderer {
 		}
 
 		gl.clear (gl.COLOR_BUFFER_BIT);
+		stage.__prepareResources (renderSession);
 		renderDisplayObject (stage, projection);
 
 	}
@@ -322,7 +323,13 @@ class GLRenderer extends AbstractRenderer {
 	public static function renderBitmap (shape:DisplayObject, renderSession:RenderSession, smooth:Bool = true):Void {
 
 		if (!shape.__renderable || shape.__worldAlpha <= 0) return;
-		if (shape.__graphics == null || shape.__graphics.__bitmap == null) return;
+		if (shape.__graphics == null ) return;
+
+		var graphics = shape.__graphics;
+
+		if (graphics.__bitmap == null) {
+			graphics.__bitmap = BitmapData.fromCanvas (graphics.__canvas, shape.renderScaleX, shape.renderScaleY);
+		}
 
 		var matrix = openfl.geom.Matrix.__temp;
 

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -571,13 +571,21 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 
 		if (__graphics != null) {
 
-			#if (js && html5)
-			CanvasGraphics.render (__graphics, renderSession, renderScaleX, renderScaleY, __isMask);
-			#elseif lime_cairo
-			CairoGraphics.render (__graphics, renderSession);
-			#end
-
 			GLRenderer.renderBitmap (this, renderSession);
+
+		}
+
+	}
+
+	private function __prepareResources (renderSession:RenderSession):Void {
+
+		if (__graphics != null) {
+
+			#if (js && html5)
+				CanvasGraphics.render (__graphics, renderSession, renderScaleX, renderScaleY, __isMask);
+			#elseif lime_cairo
+				CairoGraphics.render (__graphics, renderSession);
+			#end
 
 		}
 

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -41,6 +41,9 @@ import js.html.Element;
 @:keepSub
 class DisplayObject extends EventDispatcher implements IBitmapDrawable implements Dynamic<DisplayObject> {
 
+	private var graphicsOnly:Bool;
+
+
 	private static var __worldRenderDirty = 0;
 	private static var __worldTransformDirty = 0;
 	#if compliant_stage_events
@@ -549,6 +552,9 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 
 	}
 
+	private inline function __mustRenderGL():Bool {
+		return /*!graphicsOnly || __cacheAsBitmap ||*/ this == stage; // :TODO: test for mask (is mask or has mask), color transform?
+	}
 
 	public function __renderGL (renderSession:RenderSession):Void {
 
@@ -561,9 +567,11 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 			return;
 		}
 
-		__preRenderGL (renderSession);
-		__drawGraphicsGL (renderSession);
-		__postRenderGL (renderSession);
+		if (__mustRenderGL ()) {
+			__preRenderGL (renderSession);
+			__drawGraphicsGL (renderSession);
+			__postRenderGL (renderSession);
+		}
 
 	}
 
@@ -938,6 +946,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 	}
 
 	public function __update (transformOnly:Bool, updateChildren:Bool):Void {
+		graphicsOnly = __graphics != null;
 		__inlineUpdate(transformOnly, updateChildren);
 	}
 

--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -1,13 +1,8 @@
 package openfl.display; #if !openfl_legacy
 
 
-import lime.graphics.cairo.Cairo;
-import lime.graphics.Image;
-import openfl._internal.renderer.cairo.CairoGraphics;
 import openfl._internal.renderer.canvas.CanvasGraphics;
 import openfl._internal.renderer.DrawCommandBuffer;
-import openfl._internal.renderer.opengl.utils.RenderTexture;
-import openfl.display.Shader;
 import openfl.errors.ArgumentError;
 import openfl.display.GraphicsPathCommand;
 import openfl.display.GraphicsBitmapFill;

--- a/openfl/display/Stage.hx
+++ b/openfl/display/Stage.hx
@@ -145,6 +145,8 @@ class Stage extends DisplayObjectContainer implements IModule {
 
 		super ();
 
+		graphicsOnly = true; // temp hack
+
 		this.application = window.application;
 		this.window = window;
 

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -779,38 +779,15 @@ class TextField extends InteractiveObject {
 
 	}
 
-
-	public override function __renderGL (renderSession:RenderSession):Void {
-
-		if (__cacheAsBitmap) {
-			__isCachingAsBitmap = true;
-			__cacheGL(renderSession);
-			__isCachingAsBitmap = false;
-			return;
-		}
-
-		__preRenderGL(renderSession);
-
-		#if !disable_cairo_graphics
+	private override function __prepareResources (renderSession:RenderSession):Void {
 
 		#if lime_cairo
-		CairoTextField.render (this, renderSession);
+			CairoTextField.render (this, renderSession);
 		#else
-		CanvasTextField.render (this, renderSession);
+			CanvasTextField.render (this, renderSession);
 		#end
-
-		GLRenderer.renderBitmap (this, renderSession, false);
-
-		#else
-
-		//GLTextField.render (this, renderSession);
-
-		#end
-
-		__postRenderGL(renderSession);
 
 	}
-
 
 	private function __startCursorTimer ():Void {
 

--- a/openfl/utils/UnshrinkableArray.hx
+++ b/openfl/utils/UnshrinkableArray.hx
@@ -1,7 +1,5 @@
 package openfl.utils;
 
-import haxe.ds.Vector;
-
 abstract UnshrinkableArray<T>(UnshrinkableArrayData<T>)
 {
     public var length(get, never):Int;


### PR DESCRIPTION
These changes aim at reducing the number of canvas to webgl texture conversions which are particularly costly on Firefox.

This WIP shows a noticeable improvement in simple test case stressing that issue on Firefox but initial testing on IE/Edge seem to show a performance drop on those browsers.

Development on this feature is put on hold for now...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/266)
<!-- Reviewable:end -->
