### PR TITLE
Added graphics dispose in clearCachedTable

### DIFF
--- a/format/swf/lite/symbols/ShapeSymbol.hx
+++ b/format/swf/lite/symbols/ShapeSymbol.hx
@@ -191,9 +191,12 @@ class ShapeSymbol extends SWFSymbol {
 
 
 	private function __clearCachedTable(event:Event) {
+		graphics.dispose();
+
 		for ( cache in cachedTable ) {
 			cache.bitmapData.dispose();
 		}
+
 		if ( cachedTable.length > 0 ) {
 			cachedTable.splice(0, cachedTable.length);
 		}


### PR DESCRIPTION
The graphics objects had a reference on the cleared bitmaps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/272)
<!-- Reviewable:end -->
