### PR TITLE
Improved performance in computeFlattenedChildren

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -955,9 +955,13 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 		__inlineUpdate(transformOnly, updateChildren);
 	}
 
+	public inline function isRenderable() {
+		return (visible && !hasZeroScale() && !__isMask);
+	}
+
 	public inline function __inlineUpdate(transformOnly:Bool, updateChildren:Bool):Void {
 
-		__renderable = (visible && !hasZeroScale() && !__isMask);
+		__renderable = isRenderable();
 
 		__updateTransforms ();
 

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -1148,7 +1148,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable implement
 	}
 
 
-	public function hasMouseListener ():Bool {
+	public inline function hasMouseListener ():Bool {
 		return __mouseListenerCount > 0;
 	}
 

--- a/openfl/display/Stage.hx
+++ b/openfl/display/Stage.hx
@@ -699,7 +699,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 
 			if (stack_id.__children != null && stack_id.__children.length > 0) {
 				for(child in stack_id.__children) {
-					if (!child.__renderable || child.__worldAlpha <= 0) continue;
+					if (!child.isRenderable()) continue;
 					if (ancestorHasMouseListener) {
 						child.__mustEvaluateHitTest = true;
 					} else if (child.hasMouseListener ()) {

--- a/openfl/utils/UnshrinkableArray.hx
+++ b/openfl/utils/UnshrinkableArray.hx
@@ -53,7 +53,7 @@ abstract UnshrinkableArray<T>(UnshrinkableArrayData<T>)
         this._length = 0;
     }
 
-    public inline function remove(item:T)
+    public function remove(item:T)
     {
         var found = indexOf(item);
 
@@ -71,7 +71,7 @@ abstract UnshrinkableArray<T>(UnshrinkableArrayData<T>)
         return found >= 0;
     }
 
-    public inline function splice(from:Int, count:Int)
+    public function splice(from:Int, count:Int)
     {
         from = cast Math.max(from , 0);
         count = cast Math.min(count, this._length - from);


### PR DESCRIPTION
Several parts here:
* __allChildrenStack was a HaxeVector. It was never cleared. If at some point there were 100 elements less to update, we'd still
process those 100 old entries.
* It's not necessary to update non renderable items. When renderability is changed, update will be called ( at worst in the
next frame ). All accumulated displacement etc will then be called at that time. This does not affect movieclips playing,
because that logic is handled in __enterFrame.

* Some better inlining

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/286)
<!-- Reviewable:end -->
