### PR TITLE
Don't read pixels when calling drawGL to render into bitmap

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -439,7 +439,7 @@ class BitmapData implements IBitmapDrawable {
 				src_display_object.__update(false, true);
 			}
 		}
-		__drawGL ( renderSession, source, matrix, clipRect, smoothing, !__usingPingPongTexture, false, true);
+		__drawGL ( renderSession, source, matrix, clipRect, smoothing, !__usingPingPongTexture, false, false);
 		if ( Std.is( source, DisplayObject ) && !cached_visible ) {
 			cast(source,DisplayObject).visible = cached_visible;
 		}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/313)
<!-- Reviewable:end -->
