### PR TITLE
Call enableAttributes only once

### DIFF
--- a/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
+++ b/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
@@ -206,7 +206,6 @@ class SpriteBatch {
 		var color:Int = ((Std.int(alpha * 255)) & 0xFF) << 24 | 0xFFFFFF;
 
 		//enableAttributes(color);
-		enableAttributes(0);
 
 		var renderTargetBaseTransform = renderSession.getRenderTargetBaseTransform ();
 		var localMatrix = Matrix.pool.get ();
@@ -285,12 +284,11 @@ class SpriteBatch {
 		if (enableColor != lastEnableColor) {
 			flush();
 			lastEnableColor = enableColor;
+			attributes[2].enabled = lastEnableColor;
+			elementsPerVertex = getElementsPerVertex();
 		}
-
-		attributes[2].enabled = lastEnableColor;
-
-		elementsPerVertex = getElementsPerVertex();
 	}
+
 
 	function flush() {
 
@@ -483,6 +481,7 @@ class SpriteBatch {
 		gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
 		gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
 
+		enableAttributes(0);
 	}
 
 	inline function prepareShader(flashShader:FlashShader, ?bd:BitmapData) {


### PR DESCRIPTION
As we force the use of white color at this moment there is no need to recompute the elements count every time

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/322)
<!-- Reviewable:end -->
