### PR TITLE
allow passing Void->Void to event listeners

### DIFF
--- a/openfl/events/EventDispatcher.hx
+++ b/openfl/events/EventDispatcher.hx
@@ -260,7 +260,11 @@ class EventDispatcher implements IEventDispatcher {
 				if (listener.useCapture == capture) {
 
 					//listener.callback (event.clone ());
+					#if (js && html5)
+					untyped listener.callback.call(listener, event);
+					#else
 					listener.callCallback (event);
+					#end
 
 					if (event.__isCanceledNow) {
 


### PR DESCRIPTION
The goal of this is to avoid having to creating useless arguments all the time if you don't need the event to be passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/324)
<!-- Reviewable:end -->
