### PR TITLE
Fixed variable name listener for textfields

### DIFF
--- a/format/swf/lite/DynamicTextField.hx
+++ b/format/swf/lite/DynamicTextField.hx
@@ -120,7 +120,9 @@ class DynamicTextField extends TextField {
 	}
 
 	public override function __update (transformOnly:Bool, updateChildren:Bool):Void {
-		if ( _variableName != null && _variableName.length > 0 ) {
+		var hasVariableName = _variableName != null && _variableName.length > 0;
+		if ( hasVariableName ) {
+
 			var local_parent = this.parent;
 			while ( local_parent != null ) {
 				if ( Reflect.hasField(local_parent, _variableName) ) {
@@ -132,6 +134,9 @@ class DynamicTextField extends TextField {
 			}
 		}
 		super.__update(transformOnly, updateChildren);
+		if ( hasVariableName ) {
+			__updateDirty = true;
+		}
 	}
 
 }


### PR DESCRIPTION
Due to our smart update system, these objects are no longer updated every frame. So their value was no longer set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/326)
<!-- Reviewable:end -->
