### PR TITLE
Invisible graphics should be rendered, but masks should!

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -490,7 +490,7 @@ class CanvasGraphics {
 
 			var bounds = graphics.__bounds;
 
-			if (!graphics.__visible || graphics.__commands.length == 0 || bounds == null || bounds.width <= 0 || bounds.height <= 0) {
+			if ((!isMask && !graphics.__visible) || graphics.__commands.length == 0 || bounds == null || bounds.width <= 0 || bounds.height <= 0) {
 
 				graphics.__canvas = null;
 				graphics.__context = null;


### PR DESCRIPTION
This was broken after https://github.com/FishingCactus/openfl/pull/363

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/369)
<!-- Reviewable:end -->
