### PR TITLE
Fixed changing a displayobject's parent.

### DIFF
--- a/openfl/display/DisplayObjectContainer.hx
+++ b/openfl/display/DisplayObjectContainer.hx
@@ -60,6 +60,11 @@ class DisplayObjectContainer extends InteractiveObject {
 			__children.insert(index,child);
 		} else {
 			if (child.parent != null) {
+				// :TRICKY: We make the stage null to avoid the child being disposed.
+				// By default, removing a child makes us assume that the child should be cleaned up
+				// In this case it's only moved.
+				// :NOTE: This will still be incorrect when manually removing + adding.
+				// We should maybe use a smarter internal GC system.
 				var childStage:Stage = child.stage;
 				child.stage = null;
 				child.parent.removeChild (child);

--- a/openfl/display/DisplayObjectContainer.hx
+++ b/openfl/display/DisplayObjectContainer.hx
@@ -60,7 +60,10 @@ class DisplayObjectContainer extends InteractiveObject {
 			__children.insert(index,child);
 		} else {
 			if (child.parent != null) {
+				var childStage:Stage = child.stage;
+				child.stage = null;
 				child.parent.removeChild (child);
+				child.stage = childStage;
 			}
 
 			__children.insert(index,child);


### PR DESCRIPTION
When calling removeChild, we release the resources for the child, if it was added to the stage.
In the case of swapping parents, we don't want to do that. We keep using the child and will not
re-initialize it. Therefor it should not be disposed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/376)
<!-- Reviewable:end -->
