### PR TITLE
SimpleSprite properly reports a single frame length. //patch

### DIFF
--- a/format/swf/lite/SimpleSprite.hx
+++ b/format/swf/lite/SimpleSprite.hx
@@ -17,6 +17,9 @@ class SimpleSprite extends flash.display.MovieClip
 
         super();
 
+        __totalFrames = 1;
+        __currentFrame = 1;
+
         var bitmap = new Bitmap(Assets.getBitmapData(cast(swf.symbols.get(symbol.bitmapID),format.swf.lite.symbols.BitmapSymbol).path));
         addChild(bitmap);
         bitmap.smoothing = symbol.smooth;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/383)
<!-- Reviewable:end -->
