### PR TITLE
Call updateSWFMaskData more often. Reduced performance impact //patch

### DIFF
--- a/format/swf/lite/MovieClip.hx
+++ b/format/swf/lite/MovieClip.hx
@@ -827,6 +827,8 @@ class MovieClip extends flash.display.MovieClip {
 
 		if (!isRenderable() || __worldAlpha <= 0) return;
 
+		__updateSwfMaskData();
+
 		if (__symbol != null && __symbol.scalingGridRect != null && __9SliceBitmap != null) {
 
 			drawScale9Bitmap(renderSession);


### PR DESCRIPTION
When spam clicking buttons that add children with clipdepth, this function now shows up with a performance impact of 0.6 % self time and 1.2 % total time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/391)
<!-- Reviewable:end -->
