### PR TITLE
Removed 9-slice related throw

### DIFF
--- a/format/swf/exporters/SWFLiteExporter.hx
+++ b/format/swf/exporters/SWFLiteExporter.hx
@@ -925,16 +925,6 @@ class SWFLiteExporter {
 
 		}
 
-		// From 'scale9Grid' documentation:
-		// When the scale9Grid property is set and a movie clip is scaled, all text and child movie clips scale normally, ...
-		// :TODO: detect other tags (texts, ...)
-		if (symbol.scalingGridRect != null && hasSprite) {
-			if (hasShape) {
-                throw ":TODO: support 9 slice on sprites containing both shapes and sprites (symbol " + symbol.id + ")";
-			} else {
-				symbol.scalingGridRect = null;
-			}
-		}
 		return symbol;
 
 	}


### PR DESCRIPTION
We saw in our projects that the sprite has to be part of the 9-slice so this throw is not relevant

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/414)
<!-- Reviewable:end -->
