### PR TITLE
Put back a functional snapCoordinates

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -579,7 +579,6 @@ class CanvasGraphics {
 
 				if (snapCoordinates) {
 
-					throw ":TODO:";
 					currentTransform.setTo (transform.a, transform.b, transform.c, transform.d, transform.tx, transform.ty);
 
 				} else {
@@ -632,6 +631,9 @@ class CanvasGraphics {
 
 							case DRAW_IMAGE:
 								snappedDrawImage(data);
+
+							case LINE_STYLE:
+								lineStyle(data, isMask);
 
 							default:
 

--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -508,10 +508,6 @@ class BitmapData implements IBitmapDrawable {
 	public static function fromGraphics (graphics:Graphics, transparent:Bool = true, renderToLocalMatrix:Matrix):BitmapData {
 
 		#if (js && html5)
-			if (graphics.snapCoordinates) {
-				throw ":TODO: handle snapCoordinates";
-			}
-
 			var bounds = graphics.__bounds;
 			var bitmap = BitmapData.fromCanvas (graphics.__canvas, bounds.width, bounds.height, renderToLocalMatrix);
 


### PR DESCRIPTION
This is useful to avoid shapes 'lines-glitches'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/openfl/416)
<!-- Reviewable:end -->
